### PR TITLE
Remove unnecessary combos

### DIFF
--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -84,19 +84,5 @@
             bindings = <&kp FSLH &kp STAR>;
             label = "MACROS_COMMENT";
         };
-
-        to_russian: to_russian {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings = <&to RUS &kp LA(LG(LC(F)))>;
-            label = "TO_RUSSIAN";
-        };
-
-        to_eng: to_eng {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings = <&to BASE &kp LC(LA(LG(D)))>;
-            label = "TO_ENG";
-        };
     };
 };


### PR DESCRIPTION
They use layers, including RUS, which is not defined in your keymap. I guess it might cause the build fail