### PR TITLE
Rearrange imports in charybdis.keymap

### DIFF
--- a/config/charybdis.keymap
+++ b/config/charybdis.keymap
@@ -1,3 +1,8 @@
+#include <behaviors.dtsi>
+#include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/pointing.h>
 #include <dt-bindings/zmk/mouse.h>
 #include <behaviors/mouse_keys.dtsi>
 #include <input/processors.dtsi>
@@ -10,11 +15,6 @@
 #include "macros.dtsi"
 #include "behaviors.dtsi"
 #include "combos.dtsi"
-#include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
-#include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/outputs.h>
-#include <dt-bindings/zmk/pointing.h>
 
 #define BASE 0
 #define GAME 1


### PR DESCRIPTION
The order of imports is important. 
First we need to import all the standard zmk files, and only then our own dtsi files. Because dtsi are using them.